### PR TITLE
Update 'Join' button URL to redirect to Substack

### DIFF
--- a/components/HeroSection/HeroEnglish.tsx
+++ b/components/HeroSection/HeroEnglish.tsx
@@ -50,7 +50,7 @@ export default function HeroEnglish() {
           Computer Science,  ML/AI,  Economics,  Systems,  Physics 
         </p>
         <div className="mt-6 flex gap-4">
-            <button className="bg-black text-white p-4 w-40">Join</button>
+            <a href="https://thecatician.substack.com/" className="bg-black text-white p-4 w-40 text-center">Join</a>
             <button className="bg-gray-300 text-black p-4 w-40">Examples</button>
         </div>
       </div>

--- a/components/HeroSection/HeroSpanish.tsx
+++ b/components/HeroSection/HeroSpanish.tsx
@@ -50,7 +50,7 @@ export default function HeroEnglishSection() {
           Computer Science,  ML/AI,  Economics,  Systems,  Physics 
         </p>
         <div className="mt-6 flex gap-4">
-            <button className="bg-black text-white p-4 w-40">Join</button>
+            <a href="https://thecatician.substack.com/" className="bg-black text-white p-4 w-40 text-center">Join</a>
             <button className="bg-gray-300 text-black p-4 w-40">Examples</button>
         </div>
       </div>


### PR DESCRIPTION
This change modifies the 'Join' button in both the English and Spanish hero sections to redirect to https://thecatician.substack.com/.

The <button> element was replaced with an <a> tag, styled to maintain the original appearance.